### PR TITLE
Possible implementation for https://github.com/pre-commit/pre-commit/issues/3189

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.egg-info
 *.py[co]
+*.pytest_cache
 /.coverage
 /.tox
+/build
 /dist
 .vscode/
+testing/resources/python_hooks_repo/build/lib/foo.py

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -222,6 +222,13 @@ def _run_single_hook(
 
         if retcode:
             _subtle_line(f'- exit code: {retcode}', use_color)
+            if verbose and hook.description:
+                description = hook.description
+                if '\n' in hook.description:
+                    description = '|'
+                    for line in hook.description.splitlines():
+                        description += '\n  ' + line
+                _subtle_line(f'- description: {description}', use_color)
 
         # Print a message if failing due to file modifications
         if files_modified:

--- a/testing/resources/failing_hook_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/failing_hook_repo/.pre-commit-hooks.yaml
@@ -1,5 +1,15 @@
 -   id: failing_hook
     name: Failing hook
+    description: |
+        Failing Hook Description
+        Longer description.
+    entry: bin/hook.sh
+    language: script
+    files: .
+
+-   id: failing_short_hook
+    name: Failing short hook
+    description: Failing Short Hook Description
     entry: bin/hook.sh
     language: script
     files: .

--- a/tests/commands/install_uninstall_test.py
+++ b/tests/commands/install_uninstall_test.py
@@ -304,6 +304,13 @@ FAILING_PRE_COMMIT_RUN = re_assert.Matches(
     r'\n'
     r'Fail\n'
     r'foo\n'
+    r'\n'
+    r'Failing short hook\.+Failed\n'
+    r'- hook id: failing_short_hook\n'
+    r'- exit code: 1\n'
+    r'\n'
+    r'Fail\n'
+    r'foo\n'
     r'\n$',
 )
 

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -173,6 +173,32 @@ def test_run_all_hooks_failing(cap_out, store, repo_with_failing_hook):
     )
 
 
+def test_run_all_hooks_failing_verbose(cap_out, store, repo_with_failing_hook):
+    _test_run(
+        cap_out,
+        store,
+        repo_with_failing_hook,
+        {'verbose': True},
+        (
+            b'Failing hook',
+            b'Failed',
+            b'- hook id: failing_hook',
+            b'- exit code: 1',
+            b'description: |',
+            b'  Failing Hook Description',
+            b'  Longer description.',
+            b'Fail\nfoo.py\n',
+            b'Failing hook',
+            b'Failed',
+            b'hook id: failing_short_hook',
+            b'description: Failing Short Hook Description',
+            b'Fail\nfoo.py\n',
+        ),
+        expected_ret=1,
+        stage=True,
+    )
+
+
 def test_arbitrary_bytes_hook(cap_out, store, tempdir_factory):
     git_path = make_consuming_repo(tempdir_factory, 'arbitrary_bytes_repo')
     with cwd(git_path):


### PR DESCRIPTION
When `run` is called with `-v`, then show `hook.description` if available.

When developers run the pre-commit, they don't always understand what to or where to find more information. The hook description field is already present and often used to provide more descriptive information. For brevity this is not shown in normal cases, but this PR changes the tool behavior to show the description in verbose mode (`-v`). So most users won't see any difference but this can easily be enabled for people who want it.

Alternatives considered:
* Always show the description: Some people may not like this though as it can be spammy.
* Provide a new field: Possible but seems to be just more work with description already present and not otherwise used.
* Show the `repo` link. This is at the wrong level and has a slightly different purpose. Though description can just be set to the same url where that is correct.